### PR TITLE
Mark compatible with pypy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ if 'Yup' == True-ish:
 
 It also does some things I haven't documented yet.
 
+## Compatibility
+
+Ish is compatible with Python 2.7, 3.3+ and PyPy.
+
 ## Running Tests
 
 Install [tox](). Run `tox` in the top-level directory. This should run the
-tests against Python 2.7 and 3.1
+tests against all supported Python versions.
 
 ## Contributing to Ish
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py33,py34,pypy
 [testenv]
 deps=pytest
 commands=py.test 


### PR DESCRIPTION
I tested ish on PyPy ... and it works! So I think it makes sense to document PyPy along with Python 3 suppport in the README, and to add pypy to the tox script.

While doing so I also fixed a typo in the README stating that it runs on Python 3.1 which is wrong, in fact Python 3.3+ is required (due to the use of unicode literals).
