### PR TITLE
Make NumberIsh consider relative and absolute tolerance

### DIFF
--- a/ish.py
+++ b/ish.py
@@ -115,15 +115,13 @@ class BoolIsh(BaseIsh):
 
 @functools.total_ordering
 class NumberIsh(BaseIsh):
-    def __init__(self, value, precision=0.20001):
+    def __init__(self, value, precision=0.2):
         super(NumberIsh, self).__init__(value)
 
-        self._min = value - precision
-        self._max = value + precision
+        self._min = min(value - precision, value * (1 - precision))
+        self._max = max(value + precision, value * (1 + precision))
 
     def _to_number(self, obj):
-        if isinstance(obj, numbers.Real):
-            return obj
         try:
             return float(obj)
         except (TypeError, ValueError):

--- a/test_ish.py
+++ b/test_ish.py
@@ -39,7 +39,7 @@ def test_number_ish():
     assert 0.6 > 0-ish
     assert '0.2' == 0-ish
     assert 0.4 == 0.5-ish
-    assert 100.2 == 100-ish
+    assert 120 == 100-ish
     assert Decimal('1.2') == 1-ish
     assert Fraction('6/5') == 1-ish
 


### PR DESCRIPTION
With 42fc004 the behavor of `<number>`-ish was changed from relative to absolute tolerance that  `0.2 == 0-ish`. However, this broke `120` == `100-ish`. So in order to support both, I now calculate the absolute and relative boundaries and use the one that is most far away.

Moreover, this PR always converts the given number to `float` even if it's already a real number. That is necessary because `Fraction('6/5') > 1.2` while `float(Fraction('6/5')) == 1.2`.
