### PR TITLE
Simpliefied dispatch of True-ish and False-ish

### DIFF
--- a/ish.py
+++ b/ish.py
@@ -178,10 +178,8 @@ class Ish(object):
     Maybe = Maybe
 
     def __rsub__(self, other):
-        if other is True:
-            return BoolIsh(True)
-        if other is False:
-            return BoolIsh(False)
+        if isinstance(other, bool):
+            return BoolIsh(other)
         if isinstance(other, numbers.Real):
             return NumberIsh(other)
         if isinstance(other, basestring):


### PR DESCRIPTION
Since 42fc004, `True-ish` and `False-ish` aren't singletons anymore. So we can simplify the dispatch by just checking for `isinstance(other, bool)`.
