### PR TITLE
Add detection for non-UTF8 encodings

### DIFF
--- a/test_ish.py
+++ b/test_ish.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import print_function
 import pytest
 from decimal import Decimal
 from fractions import Fraction
@@ -19,8 +16,22 @@ def test_true_ish():
 
 
 def test_true_ish_unicode():
-    mine = u'نعم'.lower()
-    assert mine == True-ish
+    assert u'\ufee6\ufecc\ufee3' == True-ish
+
+
+def test_charset_detection():
+    # UTF-8
+    assert b'\xef\xbb\xa6\xef\xbb\x8c\xef\xbb\xa3' == True-ish
+    # UTF-16
+    assert b'\xff\xfe\xe6\xfe\xcc\xfe\xe3\xfe' == True-ish
+    # UTF-32
+    assert b'\xff\xfe\x00\x00\xe6\xfe\x00\x00\xcc\xfe\x00\x00\xe3\xfe\x00\x00' == True-ish
+    # ISO-8859-6
+    assert b'\xe6\xd9\xe5' == True-ish
+    # CP720
+    assert b'\xeb\xe3\xea' == True-ish
+    # CP1256
+    assert b'\xe4\xda\xe3' == True-ish
 
 
 def test_extra_chars():


### PR DESCRIPTION
It's great that `ish` already works around the mess of distinguishing between data and text, in particular in Python 3, by automatically decoding byte strings (as `UTF-8`). This behavior is however far incomplete. 

`UTF-8` is nice but shouldn't be naively expected or being overly encouraged. There are also other common encodings like `cp720` and `UTF-32be`, to name only a few. And nobody wants  to (or should) manually deal with encodings. Therfore it's `ish`'s responsibility to try a set of encodings before giving up.

Also, what is about alternative unicode representation? E.g. `\ufef7` (`LAM WITH ALEF WITH HAMZA ISOLATED FORM`) vs. `\u0644\u0623` (`LAM` + `ALEF WITH HAMZA`). But even more important, popular encodings like `cp720` don't support some of the more fancy froms provided by unicode. Therfore unicode normalization is necessary as well.

With this PR, all Unicode and Arabic encodings are tried until a match is found, and unicode normalization is applied to the decoded string in addition to the existing normalization logic.
