### PR TITLE
Mark compatible with Python 3.6 and fix pytest warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 
 before_install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ release = register clean --all sdist bdist_wheel upload
 max-line-length = 140
 exclude = tests/*,.ropeproject/*,build/*,docs/*
 
-[pytest]
+[tool:pytest]
 norecursedirs =
     .git
     .tox

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ],
 
     py_modules=['ish'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy
+envlist = py27,py33,py34,py35,py36,pypy
 [testenv]
 deps=
   pytest


### PR DESCRIPTION
Python 3.6 is out now, and `ish` seems to be compatible (all tests pass). So I added Python 3.6 to `tox.ini`, `.travis.yml` and `setup.py`.

While doing so, I spotted the following warning which as of pytest 3.0.5 occurs for each testenv. Renaming the section in `setup.cfg` as indicated in the warning gets rid of the warning. So I did that as well.

```
py33 recreate: /home/sebastian/src/ish/.tox/py33
py33 installdeps: pytest, coverage
py33 inst: /home/sebastian/src/ish/.tox/dist/ish-0.0.0.zip
py33 installed: coverage==4.3.4,ish==0.0.0,pkg-resources==0.0.0,py==1.4.32,pytest==3.0.5
py33 runtests: PYTHONHASHSEED='1461150617'
py33 runtests: commands[0] | coverage run setup.py test
running test
================================= test session starts =================================
platform linux -- Python 3.3.5, pytest-3.0.5, py-1.4.32, pluggy-0.4.0
rootdir: /home/sebastian/src/ish, inifile: setup.cfg
collected 8 items 

test_ish.py ........

=============================== pytest-warning summary ================================
WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
===================== 8 passed, 1 pytest-warnings in 0.25 seconds =====================
```