### PR TITLE
Update Python compatibility in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ a `ValueError`
 
 ```python
 if 'Yup' == True-ish:
-    print 'True-ish!'
+    print('True-ish!')
 ```
 
 It also does some things I haven't documented yet.
 
 ## Compatibility
 
-Ish is compatible with Python 2.7, 3.3+ and PyPy.
+Ish is compatible with Python 3.6+.
 
 ## Running Tests
 


### PR DESCRIPTION
Support for Python 2.7 and PyPy was dropped in b9c37b463342bbd8acf0f834499e64b69426009b. This updates the README to reflect that ish is only compatible with Python 3.