### PR TITLE
Add missing false strings; add Hungarian language

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ or `False` to create a TrueIsh or FalseIsh object. This can be compared with
 the value to see if it either:
 
 1. Evaluates to `True`
-2. Is a string containing the English, French, German, Danish, Dutch,
-   Afrikaans, Swedish, Norwegian, Portuguese, Irish, Esperanto or Arabic for
+2. Is a string containing the English, French, German, Danish, Swedish, Dutch,
+   Afrikaans, Norwegian, Portuguese, Irish, Esperanto, Arabic or Hungarian for
    either `Yes` or `No` (or a handful of slang words with the same meaning).
 
 If it is a string containing none of these known words, it raises

--- a/ish.py
+++ b/ish.py
@@ -19,7 +19,7 @@ BOOL_STRINGS.update(
         "yup",
         "yarp",
         "oui",  # French
-        "ja",  # German, Danish, Dutch, Afrikaans, Swedish, Norwegian
+        "ja",  # German, Danish, Swedish, Dutch, Afrikaans, Norwegian
         "sim",  # Portuguese
         "sea",  # Irish
         "jes",  # Esperanto

--- a/ish.py
+++ b/ish.py
@@ -24,6 +24,8 @@ BOOL_STRINGS.update(
         "sea",  # Irish
         "jes",  # Esperanto
         u"\u0646\u0639\u0645".lower(),  # Arabic
+        "igen",  # Hungarian
+        "igaz",  # Hungarian
     )
 )
 
@@ -38,9 +40,16 @@ BOOL_STRINGS.update(
         "narp",
         "non",  # French
         "nein",  # German
-        "nej",  # Danish
+        "nej",  # Danish, Swedish
         "nee",  # Dutch
+        "geen",  # Afrikaans
+        "nei",  # Norwegian
+        "não",  # Portugese
+        "níl",  # Irish
+        "ne",  # Esperanto
         u"\u0644\u0623".lower(),  # Arabic
+        "nem",  # Hungarian
+        "hamis",  # Hungarian
     )
 )
 


### PR DESCRIPTION
- Add missing Swedish, Afrikaans, Norwegian, Portugese, Irish and Esperanto false strings
- Add Hungarian strings

Greetings from Hungary! Saw your PyCon Ireland 2022 presentation [on YouTube](https://www.youtube.com/watch?v=jIM5urFHf2k).

I might even use this in one of my projects...

cc @judy2k 